### PR TITLE
Fix test todos

### DIFF
--- a/test.py
+++ b/test.py
@@ -251,10 +251,12 @@ class IOCTL_TestCase(Common, unittest.TestCase):
 	#enddef
 
 	def test_wrong_args(self):
-		# TODO: also check the return code?
-		with self.assertRaises(subprocess.CalledProcessError):
+		with self.assertRaises(subprocess.CalledProcessError) as contextmanager:
 			call('src/unionfsctl -xxxx 2>/dev/null')
 		#endwith
+		ex = contextmanager.exception
+		self.assertEqual(ex.returncode, 1)
+		self.assertEqual(ex.output, b'')
 	#enddef
 #endclass
 


### PR DESCRIPTION
I fixed two small TODOs in `test.py`:
1. Use a temporary directory for storing the debug output file of `unionfsctl`
2. Check the return code of `unionfsctl` when the provided argument is invalid.