### PR TITLE
Add simple write tests

### DIFF
--- a/test.py
+++ b/test.py
@@ -138,6 +138,10 @@ class UnionFS_RW_RO_TestCase(Common, unittest.TestCase):
 		with self.assertRaises(PermissionError):
 			write_to_file('union/ro1_file', 'something')
 		#endwith
+		write_to_file('union/new_file', 'something')
+		self.assertEqual(read_from_file('union/new_file'), 'something')
+		self.assertEqual(read_from_file('rw1/new_file'), 'something')
+		self.assertNotIn('new_file', os.listdir('ro1'))
 	#enddef
 #endclass
 
@@ -175,6 +179,14 @@ class UnionFS_RW_RO_COW_TestCase(Common, unittest.TestCase):
 		self.assertFalse(os.path.isfile('union/ro_file'))
 		self.assertFalse(os.path.isfile('rw1/ro_file'))
 		self.assertEqual(read_from_file('ro1/ro1_file'), 'ro1')
+		self.assertNotIn('new_file', os.listdir('ro1'))
+	#enddef
+	def test_write(self):
+		write_to_file('union/new_file', 'something')
+		self.assertEqual(read_from_file('union/new_file'), 'something')
+		self.assertEqual(read_from_file('rw1/new_file'), 'something')
+		self.assertEqual(read_from_file('ro1/ro1_file'), 'ro1')
+		self.assertNotIn('new_file', os.listdir('ro1'))
 	#enddef
 #endclass
 
@@ -202,6 +214,10 @@ class UnionFS_RO_RW_TestCase(Common, unittest.TestCase):
 		with self.assertRaises(PermissionError):
 			write_to_file('union/ro1_file', 'something')
 		#endwith
+		with self.assertRaises(PermissionError):
+		    write_to_file('union/new_file', 'something')
+		self.assertNotIn('new_file', os.listdir('ro1'))
+		self.assertNotIn('new_file', os.listdir('rw1'))
 	#enddef
 #endclass
 
@@ -228,6 +244,10 @@ class UnionFS_RO_RW_COW_TestCase(Common, unittest.TestCase):
 		with self.assertRaises(PermissionError):
 			write_to_file('union/ro1_file', 'something')
 		#endwith
+		write_to_file('union/new_file', 'something')
+		self.assertIn('new_file', os.listdir('rw1'))
+		self.assertEqual(read_from_file('rw1/new_file'), 'something')
+		self.assertNotIn('new_file', os.listdir('ro1'))
 	#enddef
 #endclass
 


### PR DESCRIPTION
I added tests to check the behaviour when new files are created. For non-COW, creating a new file must only work if the RW directory has a higher priority (thus, in the RW-RO scenario). For COW, creating a new file must always work. Also, a new file must never be placed in the RO directory.