### PR TITLE
Use gcov for coverage information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,19 @@ SBINDIR=/sbin
 build:
 	$(MAKE) -C src/
 
+build_coverage:
+	CFLAGS="-g -O0 -fprofile-arcs -ftest-coverage" \
+	       LDFLAGS="-lgcov -coverage" $(MAKE) -C src/
+
 clean:
 	$(MAKE) -C src/ clean
+
+test_coverage: clean build_coverage coverage
+	./test.py
+	(cd src && gcovr -r . --html -o ../coverage/coverage.html --html-details)
+
+coverage:
+	mkdir $@
 
 install: build
 	install -d $(DESTDIR)$(PREFIX)$(BINDIR)


### PR DESCRIPTION
With the target build_coverage, make will build gcov-enabled executables. The target
test_coverage will use these executables to run test.py and extract coverage information
with gcovr.

NOTE: gcovr must already be installed on the machine. It will then produce a directory coverage/ with a file `coverage.html` that contains the information in colorful form:

![coverage](https://cloud.githubusercontent.com/assets/224554/10886049/92cfc31e-8180-11e5-8594-715d6775ef04.png)
![coverage2](https://cloud.githubusercontent.com/assets/224554/10886107/cdda6c0c-8180-11e5-8bf7-14dd9c375c83.png)
