### PR TITLE
Fixup PR#33

### DIFF
--- a/umltest.sh
+++ b/umltest.sh
@@ -21,7 +21,7 @@ rm -r ro1 ro2 rw1 rw2 union
 	cd "$CURDIR"
 	python3 --version
         # sleep if it fails to allow writing stuff
-	RUNNING_ON_TRAVIS_CI= python3 test.py
+	RUNNING_ON_TRAVIS_CI=1 python3 test.py
 	echo Success
 )
 echo "\$?" > "$CURDIR"/umltest.status


### PR DESCRIPTION
dbf2aff (#33) broke the testsuite on systems were the testsuite was not run by root, as the file /dev/mtab usually does not exist. The file meant to be checked instead is /etc/mtab. Alas, this file also exists on
User Mode Linux and is thus not useful to determine whether to run fusermount -u or umount. The fix for
this is to simply distinguish between a normal run and a run on User Mode Linux by use of an environment variable introduced in dbf2aff.

This changeset also fixes the skip logic for IOCTL_TestCase, which skipped the tests no matter if the environment variable was unset or set to the empty string.