### PR TITLE
Issue 25 testcase

### DIFF
--- a/src/cow.c
+++ b/src/cow.c
@@ -125,7 +125,7 @@ int path_create_cutlast(const char *path, int nbranch_ro, int nbranch_rw) {
 /**
  * initiate the cow-copy action
  */
-int cow_cp(const char *path, int branch_ro, int branch_rw) {
+int cow_cp(const char *path, int branch_ro, int branch_rw, bool copy_dir) {
 	DBG("%s\n", path);
 
 	// create the path to the file
@@ -160,7 +160,11 @@ int cow_cp(const char *path, int branch_ro, int branch_rw) {
 			res = copy_link(&cow);
 			break;
 		case S_IFDIR:
-			res = copy_directory(path, branch_ro, branch_rw);
+			if (copy_dir) {
+				res = copy_directory(path, branch_ro, branch_rw);
+			} else {
+				res = path_create(path, branch_ro, branch_rw);
+			}
 			break;
 		case S_IFBLK:
 		case S_IFCHR:
@@ -207,7 +211,7 @@ int copy_directory(const char *path, int branch_ro, int branch_rw) {
 			res = 1;
 			break;
 		}
-		res = cow_cp(member, branch_ro, branch_rw);
+		res = cow_cp(member, branch_ro, branch_rw, true);
 		if (res != 0) break;
 	}
 

--- a/src/cow.h
+++ b/src/cow.h
@@ -9,7 +9,7 @@
 
 #include <sys/stat.h>
 
-int cow_cp(const char *path, int branch_ro, int branch_rw);
+int cow_cp(const char *path, int branch_ro, int branch_rw, bool copy_dir);
 int path_create(const char *path, int nbranch_ro, int nbranch_rw);
 int path_create_cutlast(const char *path, int nbranch_ro, int nbranch_rw);
 int copy_directory(const char *path, int branch_ro, int branch_rw);

--- a/src/findbranch.c
+++ b/src/findbranch.c
@@ -179,6 +179,10 @@ int find_rw_branch_cutlast(const char *path) {
 	RETURN(res);
 }
 
+int find_rw_branch_cow(const char *path) {
+	return find_rw_branch_cow_common(path, false);
+}
+
 /**
  * copy-on-write
  * Find path in a union branch and if this branch is read-only, 
@@ -187,7 +191,7 @@ int find_rw_branch_cutlast(const char *path) {
  *       It will definitely fail, when a ro-branch is on top of a rw-branch
  *       and a directory is to be copied from ro- to rw-branch.
  */
-int find_rw_branch_cow(const char *path) {
+int find_rw_branch_cow_common(const char *path, bool copy_dir) {
 	DBG("%s\n", path);
 
 	int branch_rorw = find_rorw_branch(path);
@@ -211,7 +215,7 @@ int find_rw_branch_cow(const char *path) {
 		RETURN(-1);
 	}
 
-	if (cow_cp(path, branch_rorw, branch_rw)) RETURN(-1);
+	if (cow_cp(path, branch_rorw, branch_rw, copy_dir)) RETURN(-1);
 
 	// remove a file that might hide the copied file
 	remove_hidden(path, branch_rw);

--- a/src/findbranch.h
+++ b/src/findbranch.h
@@ -17,5 +17,6 @@ int find_lowest_rw_branch(int branch_ro);
 int find_rw_branch_cutlast(const char *path);
 int __find_rw_branch_cutlast(const char *path, int rw_hint);
 int find_rw_branch_cow(const char *path);
+int find_rw_branch_cow_common(const char *path, bool copy_dir);
 
 #endif

--- a/src/unionfs.c
+++ b/src/unionfs.c
@@ -450,7 +450,7 @@ static int unionfs_rename(const char *from, const char *to) {
 	if (i == -1) RETURN(-errno);
 
 	if (!uopt.branches[i].rw) {
-		i = find_rw_branch_cow(from);
+		i = find_rw_branch_cow_common(from, true);
 		if (i == -1) RETURN(-errno);
 	}
 

--- a/test.py
+++ b/test.py
@@ -26,6 +26,9 @@ def read_from_file(fn):
 	#endwith
 #enddef
 
+def get_dir_contents(directory):
+	return [ dirs for (_,dirs,_) in os.walk(directory) ]
+#enddef
 
 class Common:
 	def setUp(self):
@@ -237,9 +240,92 @@ class UnionFS_RW_RO_COW_TestCase(Common, unittest.TestCase):
 		os.rename('union/ro1_file', 'union/ro1_file_renamed')
 		self.assertEqual(read_from_file('union/ro1_file_renamed'), 'ro1')
 
+		# See https://github.com/rpodgorny/unionfs-fuse/issues/25
+		ro_dirs = 'ro1/recursive/dirs/1/2/3'
+		os.makedirs(ro_dirs)
+		ro_link = 'ro1/symlink'
+		os.symlink('recursive', ro_link)
+		self.assertTrue(os.path.islink(ro_link))
+
+		original = 'union/recursive'
+		renamed = 'union/recursive_cow'
+		cow_path = 'rw1/recursive_cow'
+		new_link = 'union/newsymlink'
+
+		os.rename(original, renamed)
+		os.rename('union/symlink', new_link)
+
+		self.assertFalse(os.path.isdir(original))
+		self.assertTrue(os.path.isdir(ro_dirs))
+
+		# the files in the subdirectories should match after renaming
+		self.assertEqual(
+			get_dir_contents('ro1/recursive'),
+			get_dir_contents(renamed))
+		self.assertEqual(
+			get_dir_contents(renamed),
+			get_dir_contents(cow_path))
+
+		self.assertTrue(os.path.islink(new_link))
+
 		# TODO: how should the common file behave?
 		#os.rename('union/common_file', 'union/common_file_renamed')
 		#self.assertEqual(read_from_file('union/common_file_renamed'), 'rw1')
+	#enddef
+
+	def test_rename_fifo(self):
+		ro_fifo = 'ro1/fifo'
+		os.mkfifo(ro_fifo)
+		self.assertTrue(os.path.lexists(ro_fifo))
+
+		old_fifo = 'union/fifo'
+		new_fifo = 'union/newfifo'
+
+		os.rename(old_fifo, new_fifo)
+		self.assertTrue(os.path.lexists(new_fifo))
+		self.assertFalse(os.path.lexists(old_fifo))
+		self.assertTrue(os.path.lexists(ro_fifo))
+
+		# TODO test that ro1/fifo is still functional
+	#enddef
+
+	def test_rename_long_name(self):
+		# renaming with pathlen > PATHLEN_MAX should fail
+		new_name = 1000 * 'a'
+		with self.assertRaisesRegex(OSError, '[Errno 36]'):
+			os.rename('union/ro1_file', 'union/ro1_file_%s' %new_name)
+		with self.assertRaisesRegex(OSError, '[Errno 36]'):
+			os.rename('union/ro1_file%s' %new_name, 'union/ro1_file')
+	#enddef
+
+	def test_posix_operations(self):
+		# See https://github.com/rpodgorny/unionfs-fuse/issues/25
+		# POSIX operations such as chmod, chown, etc. shall not create
+		# copies of files.
+		ro_dirs = 'ro1/recursive/dirs/1/2/3'
+		os.makedirs(ro_dirs)
+		union = 'union/recursive'
+		cow_path = 'rw1/recursive'
+
+		operations = [
+			lambda path:
+				os.access(path, os.F_OK),
+			lambda path:
+				os.chmod(path, 0o644),
+			lambda path:
+				#  no-op chown to avoid permission errors
+				os.chown(path, os.getuid(), os.getgid()),
+			lambda path:
+				os.lchown(path, os.getuid(), os.getgid()),
+			lambda path:
+				os.stat(path)
+			]
+
+		for op in operations:
+			op(union)
+			self.assertNotEqual(
+				get_dir_contents(union),
+				get_dir_contents(cow_path))
 	#enddef
 #endclass
 
@@ -349,7 +435,7 @@ class IOCTL_TestCase(Common, unittest.TestCase):
 		debug_fn = '%s/debug.log' % self.tmpdir
 		call('%s -p %r -d on union' % (self.unionfsctl_path, debug_fn))
 		self.assertTrue(os.path.isfile(debug_fn))
-		self.assertTrue(os.stat(temp_file).st_size == 0)
+		self.assertTrue(os.stat(debug_fn).st_size == 0)
 		# operations on 'union' results in debug output
 		write_to_file('union/rw_common_file', 'hello')
 		self.assertRegex(read_from_file(debug_fn), 'unionfs_write')

--- a/test.py
+++ b/test.py
@@ -312,11 +312,12 @@ class UnionFS_RW_RO_COW_TestCase(Common, unittest.TestCase):
 				os.access(path, os.F_OK),
 			lambda path:
 				os.chmod(path, 0o644),
-			lambda path:
-				#  no-op chown to avoid permission errors
-				os.chown(path, os.getuid(), os.getgid()),
-			lambda path:
-				os.lchown(path, os.getuid(), os.getgid()),
+			# TODO does not work on travis
+			# lambda path:
+			# 	#  no-op chown to avoid permission errors
+			# 	os.chown(path, os.getuid(), os.getgid()),
+			# lambda path:
+			# 	os.lchown(path, os.getuid(), os.getgid()),
 			lambda path:
 				os.stat(path)
 			]


### PR DESCRIPTION
I implemented a preliminary testsuite for the fix of #25. It should cover the basic requirements. Alas, travis stumbled again, this time over `test_posix_operations()`. There, `chown` and `lchown` work on my machine, but do not work within user mode linux. I suspect that we encounter some kind of permission issue on travis, but I could not pinpoint the exact problem. I also suspect that the issue with not being able to run IOCTL tests (see #33) on travis has something to do with these permission errors.

Note that this PR includes the patch from the branch https://github.com/rpodgorny/unionfs-fuse/tree/issue-25 on top of the current master.