### PR TITLE
include asm/ioctl.h for _IOC_SIZE

### DIFF
--- a/src/unionfs.c
+++ b/src/unionfs.c
@@ -32,6 +32,7 @@
 #include <sys/types.h>
 #include <sys/time.h>
 #include <inttypes.h>
+#include <asm/ioctl.h>
 
 #ifdef linux
 	#include <sys/vfs.h>


### PR DESCRIPTION
On musl libc the build fails:

```
make -C src/
make[1]: Entering directory '/home/clandmeter/aports/main/unionfs-fuse/src/unionfs-fuse-1.0/src'
gcc -Os -fomit-frame-pointer -Wall -Os -fomit-frame-pointer -I/usr/include/fuse -D_FILE_OFFSET_BITS=64   -DFUSE_USE_VERSION=26 -DLIBC_XATTR   -c -o unionfs.o unionfs.c
unionfs.c: In function 'unionfs_ioctl':
unionfs.c:293:30: warning: implicit declaration of function '_IOC_SIZE' [-Wimplicit-function-declaration]
   set_debug_path(debug_path, _IOC_SIZE(cmd));
                              ^
gcc -Os -fomit-frame-pointer -Wall -Os -fomit-frame-pointer -I/usr/include/fuse -D_FILE_OFFSET_BITS=64   -DFUSE_USE_VERSION=26 -DLIBC_XATTR   -c -o opts.o opts.c
gcc -Os -fomit-frame-pointer -Wall -Os -fomit-frame-pointer -I/usr/include/fuse -D_FILE_OFFSET_BITS=64   -DFUSE_USE_VERSION=26 -DLIBC_XATTR   -c -o debug.o debug.c
gcc -Os -fomit-frame-pointer -Wall -Os -fomit-frame-pointer -I/usr/include/fuse -D_FILE_OFFSET_BITS=64   -DFUSE_USE_VERSION=26 -DLIBC_XATTR   -c -o findbranch.o findbranch.c
gcc -Os -fomit-frame-pointer -Wall -Os -fomit-frame-pointer -I/usr/include/fuse -D_FILE_OFFSET_BITS=64   -DFUSE_USE_VERSION=26 -DLIBC_XATTR   -c -o readdir.o readdir.c
gcc -Os -fomit-frame-pointer -Wall -Os -fomit-frame-pointer -I/usr/include/fuse -D_FILE_OFFSET_BITS=64   -DFUSE_USE_VERSION=26 -DLIBC_XATTR   -c -o general.o general.c
gcc -Os -fomit-frame-pointer -Wall -Os -fomit-frame-pointer -I/usr/include/fuse -D_FILE_OFFSET_BITS=64   -DFUSE_USE_VERSION=26 -DLIBC_XATTR   -c -o unlink.o unlink.c
gcc -Os -fomit-frame-pointer -Wall -Os -fomit-frame-pointer -I/usr/include/fuse -D_FILE_OFFSET_BITS=64   -DFUSE_USE_VERSION=26 -DLIBC_XATTR   -c -o rmdir.o rmdir.c
gcc -Os -fomit-frame-pointer -Wall -Os -fomit-frame-pointer -I/usr/include/fuse -D_FILE_OFFSET_BITS=64   -DFUSE_USE_VERSION=26 -DLIBC_XATTR   -c -o cow.o cow.c
gcc -Os -fomit-frame-pointer -Wall -Os -fomit-frame-pointer -I/usr/include/fuse -D_FILE_OFFSET_BITS=64   -DFUSE_USE_VERSION=26 -DLIBC_XATTR   -c -o cow_utils.o cow_utils.c
gcc -Os -fomit-frame-pointer -Wall -Os -fomit-frame-pointer -I/usr/include/fuse -D_FILE_OFFSET_BITS=64   -DFUSE_USE_VERSION=26 -DLIBC_XATTR   -c -o string.o string.c
gcc -Os -fomit-frame-pointer -Wall -Os -fomit-frame-pointer -I/usr/include/fuse -D_FILE_OFFSET_BITS=64   -DFUSE_USE_VERSION=26 -DLIBC_XATTR   -c -o usyslog.o usyslog.c
gcc -Os -fomit-frame-pointer -Wall -Os -fomit-frame-pointer -I/usr/include/fuse -D_FILE_OFFSET_BITS=64   -DFUSE_USE_VERSION=26 -DLIBC_XATTR   -c -o hashtable.o hashtable.c
gcc -Os -fomit-frame-pointer -Wall -Os -fomit-frame-pointer -I/usr/include/fuse -D_FILE_OFFSET_BITS=64   -DFUSE_USE_VERSION=26 -DLIBC_XATTR   -c -o hashtable_itr.o hashtable_itr.c
gcc -Wl,--as-needed  -o unionfs unionfs.o opts.o debug.o findbranch.o readdir.o general.o unlink.o rmdir.o cow.o cow_utils.o string.o usyslog.o hashtable.o hashtable_itr.o -lfuse -pthread   -lpthread
unionfs.o: In function `unionfs_ioctl':
unionfs.c:(.text+0x58): undefined reference to `_IOC_SIZE'
collect2: error: ld returned 1 exit status
Makefile:25: recipe for target 'unionfs' failed
make[1]: *** [unionfs] Error 1
make[1]: Leaving directory '/home/clandmeter/aports/main/unionfs-fuse/src/unionfs-fuse-1.0/src'
Makefile:6: recipe for target 'build' failed
make: *** [build] Error 2
```