### PR TITLE
Revert to old pre-1.0 meta directory

### DIFF
--- a/src/unionfs.h
+++ b/src/unionfs.h
@@ -10,7 +10,7 @@
 #define PATHLEN_MAX 1024
 #define HIDETAG "_HIDDEN~"
 
-#define METANAME ".unionfs-fuse"
+#define METANAME ".unionfs"
 #define METADIR (METANAME  "/") // string concetanation!
 
 // fuse meta files, we might want to hide those


### PR DESCRIPTION
Unionfs changed its meta directory from .unionfs to .unionfs-fuse with the
unionfs -> unionfs-fuse rename.  The rename later got reverted everywhere
but the meta directory, so now unionfs doesn't find the whiteout files from
older releases.

Revert back to the pre-1.0 behaviour to fix this.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>