### PR TITLE
Fix incorrect ns calculation

### DIFF
--- a/src/unionfs.c
+++ b/src/unionfs.c
@@ -683,9 +683,9 @@ static int unionfs_utimens(const char *path, const struct timespec ts[2]) {
 #else
 	struct timeval tv[2];
 	tv[0].tv_sec = ts[0].tv_sec;
-	tv[0].tv_usec = ts[0].tv_nsec * 1000;
+	tv[0].tv_usec = ts[0].tv_nsec / 1000;
 	tv[1].tv_sec = ts[1].tv_sec;
-	tv[1].tv_usec = ts[1].tv_nsec * 1000;
+	tv[1].tv_usec = ts[1].tv_nsec / 1000;
 	int res = utimes(p, tv);
 #endif
 

--- a/test.py
+++ b/test.py
@@ -185,6 +185,10 @@ class UnionFS_RW_RO_TestCase(Common, unittest.TestCase):
 		#os.rename('union/common_file', 'union/common_file_renamed')
 		#self.assertEqual(read_from_file('union/common_file_renamed'), 'rw1')
 	#enddef
+
+	def test_copystat(self):
+		shutil.copystat('union/ro1_file', 'union/rw1_file')
+	#enddef
 #endclass
 
 
@@ -240,6 +244,10 @@ class UnionFS_RW_RO_COW_TestCase(Common, unittest.TestCase):
 		# TODO: how should the common file behave?
 		#os.rename('union/common_file', 'union/common_file_renamed')
 		#self.assertEqual(read_from_file('union/common_file_renamed'), 'rw1')
+	#enddef
+
+	def test_copystat(self):
+		shutil.copystat('union/ro1_file', 'union/rw1_file')
 	#enddef
 #endclass
 


### PR DESCRIPTION
The tests below were failing on FreeBSD. The changed made cause them to pass.

Basically, converting the nsec to usec was backwards. :smile: