### PR TITLE
Fixes ioctl.h include on OSX (and perhaps others).

### DIFF
--- a/src/unionfs.c
+++ b/src/unionfs.c
@@ -32,7 +32,7 @@
 #include <sys/types.h>
 #include <sys/time.h>
 #include <inttypes.h>
-#include <asm/ioctl.h>
+#include <sys/ioctl.h>
 
 #ifdef linux
 	#include <sys/vfs.h>


### PR DESCRIPTION
Including asm/ioctl.h on OSX doesn't work, but sys/ioctl.h (as
specified in the man page) does.  Man pages for Linux, FreeBSD,
OpenBSD, and NetBSD all also specfy sys/ioctl.h, so it's unclear
where asm/ioctl.h came from.

It appears that this include was originally added as asm/ioctl.h,
so it was never changed from sys/ to asm/ to fix anything.  Instead,
it's probably just been incorrect all along, but happened to work
where tested.

TESTED:
Now builds (and works) on OSX.  Also builds on Ubuntu.