### PR TITLE
add access() support

### DIFF
--- a/src/fuse_ops.c
+++ b/src/fuse_ops.c
@@ -190,6 +190,18 @@ static int unionfs_getattr(const char *path, struct stat *stbuf) {
 	RETURN(0);
 }
 
+static int unionfs_access(const char *path, int mask) {
+	struct stat s;
+
+	if (unionfs_getattr(path, &s) != 0)
+		RETURN(-ENOENT);
+
+	if (access(path, mask) == -1)
+		RETURN(-errno);
+
+	RETURN(0);
+}
+
 /**
  * init method
  * called before first access to the filesystem
@@ -783,6 +795,7 @@ struct fuse_operations unionfs_oper = {
 	.flush = unionfs_flush,
 	.fsync = unionfs_fsync,
 	.getattr = unionfs_getattr,
+	.access = unionfs_access,
 	.init = unionfs_init,
 #if FUSE_VERSION >= 28
 	.ioctl = unionfs_ioctl,


### PR DESCRIPTION
The access() is not implemented in unionfs-fuse, and programs like "test -x file" always report 0/success.

```
unionfs -ocow,relaxed_permissions rw=RW:ro=RO u
touch u/x
test -x u/x && echo x

```