### PR TITLE
Implement access() for "cow,relaxed_permissions" use case

### DIFF
--- a/src/fuse_ops.c
+++ b/src/fuse_ops.c
@@ -190,6 +190,24 @@ static int unionfs_getattr(const char *path, struct stat *stbuf) {
 	RETURN(0);
 }
 
+static int unionfs_access(const char *path, int mask) {
+	struct stat s;
+
+	if (unionfs_getattr(path, &s) != 0)
+		RETURN(-ENOENT);
+
+	if ((mask & X_OK) && (s.st_mode & S_IXUSR) == 0)
+		RETURN(-EACCES);
+
+	if ((mask & W_OK) && (s.st_mode & S_IWUSR) == 0)
+		RETURN(-EACCES);
+
+	if ((mask & R_OK) && (s.st_mode & S_IRUSR) == 0)
+		RETURN(-EACCES);
+
+	RETURN(0);
+}
+
 /**
  * init method
  * called before first access to the filesystem
@@ -783,6 +801,7 @@ struct fuse_operations unionfs_oper = {
 	.flush = unionfs_flush,
 	.fsync = unionfs_fsync,
 	.getattr = unionfs_getattr,
+	.access = unionfs_access,
 	.init = unionfs_init,
 #if FUSE_VERSION >= 28
 	.ioctl = unionfs_ioctl,

--- a/test_all.py
+++ b/test_all.py
@@ -477,5 +477,19 @@ class IOCTL_TestCase(Common, unittest.TestCase):
 		self.assertEqual(ex.output, b'')
 
 
+class UnionFS_RW_RO_COW_Relaxed_TestCase(Common, unittest.TestCase):
+	def setUp(self):
+		super().setUp()
+		self.mount('%s -o cow,relaxed_permissions rw1=rw:ro1=ro union' % self.unionfs_path)
+
+	def test_access(self):
+		self.assertFalse(os.access('union/file', os.F_OK))
+		write_to_file('union/file', 'something')
+		os.chmod('union/file', 0o222) # w--w--w--
+		self.assertFalse(os.access('union/file', os.R_OK))
+		os.chmod('union/file', 0o444) # r--r--r--
+		self.assertFalse(os.access('union/file', os.W_OK))
+		self.assertFalse(os.access('union/file', os.X_OK))
+
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
This is a duplicate of #62, but with a  test case.
