### PR TITLE
Even allocation of files among writable branches

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -8,7 +8,9 @@
 #define DEBUG_H
 
 #include <errno.h>
+#include <sys/time.h>
 #include "opts.h"
+#include "general.h"
 
 #define DBG_IN() DBG("\n");
 
@@ -17,8 +19,12 @@
 		if (!uopt.debug) break; \
 		int _errno = errno; \
 		FILE* dbgfile = get_dbgfile(); \
-		fprintf(stderr, "%s(): %d: ", __func__, __LINE__); \
-		fprintf(dbgfile, "%s(): %d: ", __func__, __LINE__); \
+		struct timeval _tv_dbg; \
+		gettimeofday(&_tv_dbg, NULL); \
+		print_iso8601(stderr, _tv_dbg); \
+		print_iso8601(dbgfile, _tv_dbg); \
+		fprintf(stderr, " %s(): %d: ", __func__, __LINE__); \
+		fprintf(dbgfile, " %s(): %d: ", __func__, __LINE__); \
 		fprintf(stderr, format, ##__VA_ARGS__); \
 		fprintf(dbgfile, format, ##__VA_ARGS__); \
 		fflush(stderr); \

--- a/src/findbranch.h
+++ b/src/findbranch.h
@@ -14,6 +14,7 @@ typedef enum searchflag {
 
 int find_rorw_branch(const char *path);
 int find_lowest_rw_branch(int branch_ro);
+int find_evenly_rw_branch();
 int find_rw_branch_cutlast(const char *path);
 int __find_rw_branch_cutlast(const char *path, int rw_hint);
 int find_rw_branch_cow(const char *path);

--- a/src/general.c
+++ b/src/general.c
@@ -22,6 +22,7 @@
 #include <pwd.h>
 #include <grp.h>
 #include <pthread.h>
+#include <sys/time.h>
 
 #include "unionfs.h"
 #include "opts.h"
@@ -212,4 +213,15 @@ int set_owner(const char *path) {
 		}
 	}
 	RETURN(0);
+}
+
+void print_iso8601(FILE *file, struct timeval tv)
+{
+	char timestampbuf[100];
+	struct tm tm;
+
+	localtime_r(&tv.tv_sec, &tm);
+	strftime(timestampbuf, sizeof("YYYY-MM-ddTHH:mm:ss.SSS+0000"), "%Y-%m-%dT%H:%M:%S.000%z", &tm);
+	sprintf(timestampbuf + 20, "%03ld%s", tv.tv_usec / 1000, timestampbuf + 23);
+	fprintf(file, timestampbuf);
 }

--- a/src/general.h
+++ b/src/general.h
@@ -27,6 +27,7 @@ int hide_dir(const char *path, int branch_rw);
 filetype_t path_is_dir (const char *path);
 int maybe_whiteout(const char *path, int branch_rw, enum whiteout mode);
 int set_owner(const char *path);
+void print_iso8601(FILE *file, struct timeval tv);
 
 
 #endif

--- a/src/general.h
+++ b/src/general.h
@@ -28,6 +28,8 @@ filetype_t path_is_dir (const char *path);
 int maybe_whiteout(const char *path, int branch_rw, enum whiteout mode);
 int set_owner(const char *path);
 void print_iso8601(FILE *file, struct timeval tv);
+uint64_t randupto64(uint64_t max);
+int statvfs_local(const char *path, struct statvfs *stbuf);
 
 
 #endif

--- a/src/opts.c
+++ b/src/opts.c
@@ -286,6 +286,9 @@ static void print_help(const char *progname) {
         "                           want to have a union of \"/\" \n"
 	"    -o cow                 enable copy-on-write\n"
 	"                           mountpoint\n"
+	"    -o even                distribute file allocation evenly among\n"
+	"                           writable branches\n"
+	"                           the most free place\n"
 	"    -o debug_file          file to write debug information into\n"
 	"    -o dirs=branch[=RO/RW][:branch...]\n"
 	"                           alternate way to specify directories to merge\n"
@@ -394,6 +397,9 @@ int unionfs_opt_proc(void *data, const char *arg, int key, struct fuse_args *out
 			return 0;
 		case KEY_RELAXED_PERMISSIONS:
 			uopt.relaxed_permissions = true;
+			return 0;
+		case KEY_EVEN_PLACEMENT:
+			uopt.even = true;
 			return 0;
 		case KEY_VERSION:
 			printf("unionfs-fuse version: "VERSION"\n");

--- a/src/opts.h
+++ b/src/opts.h
@@ -30,6 +30,7 @@ typedef struct {
 	pthread_rwlock_t dbgpath_lock; // locks dbgpath
 	bool hide_meta_files;
 	bool relaxed_permissions;
+	bool even;
 
 } uopt_t;
 
@@ -45,6 +46,7 @@ enum {
 	KEY_NOINITGROUPS,
 	KEY_RELAXED_PERMISSIONS,
 	KEY_STATFS_OMIT_RO,
+	KEY_EVEN_PLACEMENT,
 	KEY_VERSION
 };
 

--- a/src/unionfs.c
+++ b/src/unionfs.c
@@ -24,6 +24,7 @@
 static struct fuse_opt unionfs_opts[] = {
 	FUSE_OPT_KEY("chroot=%s,", KEY_CHROOT),
 	FUSE_OPT_KEY("cow", KEY_COW),
+	FUSE_OPT_KEY("even", KEY_EVEN_PLACEMENT),
 	FUSE_OPT_KEY("debug_file=%s", KEY_DEBUG_FILE),
 	FUSE_OPT_KEY("dirs=%s", KEY_DIRS),
 	FUSE_OPT_KEY("--help", KEY_HELP),
@@ -88,6 +89,7 @@ int main(int argc, char *argv[]) {
 #endif
 
 	umask(0);
+	srand(time(NULL));
 	int res = fuse_main(args.argc, args.argv, &unionfs_oper, NULL);
 	RETURN(uopt.doexit ? uopt.retval : res);
 }


### PR DESCRIPTION
Unionfs can be used as poor man's clustered storage. To make this use case feasible, it's desired that file creations are distributed evenly among the writable branches (using a heuristics that a given new file is randomly placed on branches with likelihoods proportional to available space).

To ease debugging while I was working on this feature, I added timestamps to the debug messages. I include that in the PR as a nicety, but it's not essential for the feature delivered.