### PR TITLE
fix man page typos and wording

### DIFF
--- a/man/unionfs.8
+++ b/man/unionfs.8
@@ -20,9 +20,9 @@ unionfs\-fuse \- A userspace unionfs implementation
 .PP
 It first tries to access the file on the top branch and if the file does not exist
 there, it continues on lower level branches.
-If the user tries to modify a file on a lower level read\-only branch
-the file is copied to a higher level read\-write branch if the
-\fBcopy\-on\-write (cow) \fR mode was enabled.
+If the user tries to modify a file on a lower level read\-only branch while
+.B copy\-on\-write (cow)
+mode is enabled, the file will be copied to a higher level read\-write branch.
 .SH "OPTIONS"
 Below is a summary of unionfs options
 .TP
@@ -64,11 +64,11 @@ to stderr and a debug file (./unionfs_debug.log by default).
 Write unionfs debug information into that file.
 .TP
 \fB\-o max_files=number
-Maximum number of open files. Most system have a default of 1024 open
-files per process. For example if unionfs serves "/" applications like
-KDE or GNOME might have much more open files, which will make the unionfs
-process to exceed this limit. Suggested for "/" is >16000 or even >32000 files.
-If this limit exceeds unionfs will not be able to open further files.
+Maximum number of open files. Most systems have a default limit of 1024
+open files per process. For example if unionfs serves "/", applications
+like KDE or GNOME might have many open files, making the unionfs process
+reach this limit and unable to open further files. Suggested value for "/"
+is >16000 or even >32000 files.
 .TP
 \fB\-o noinitgroups
 Since version 0.23 without any effect, just left over for compatibility.

--- a/man/unionfs.8
+++ b/man/unionfs.8
@@ -16,7 +16,7 @@ unionfs\-fuse \- A userspace unionfs implementation
              \fBtop_branch:lower_branch:...:lowest_branch \fR
              \fBmount_point\fR
 .SH "DESCRIPTION"
-\fBunionfs\fR overlays several directory into one single mount point.
+\fBunionfs\fR overlays several directories into one single mount point.
 .PP
 It first tries to access the file on the top branch and if the file does not exist
 there, it continues on lower level branches.
@@ -27,11 +27,11 @@ the file is copied to a higher level read\-write branch if the
 Below is a summary of unionfs options
 .TP
 \fB\-o chroot=path
-Path to chroot into. By using this option unionfs
+Path to chroot into. By using this option, unionfs
 may be used for live CDs or live USB sticks, etc. So it can serve
 "/" as filesystem. If you do not specify this option and try to use
-it for "/" it will deadlock on calling 'pivot_root'.
-If you do set this option, you also need to specify the branches relativly
+it for "/", it will deadlock on calling 'pivot_root'.
+If you set this option, you also need to specify the branches relatively
 to the given chroot directory. See examples/S01a-unionfs-live-cd.sh
 for an example.
 .TP
@@ -40,16 +40,15 @@ Enable copy\-on\-write
 .TP
 \fB\-o hide_meta_files
 In our unionfs root path we have a .unionfs directory that includes
-metadata, such as hidden (deleted) files. This options make this
+metadata, such as hidden (deleted) files. This option makes this
 directory invisible from readdir(), so for example "ls -la /union_root/"
 will not show it. However, this directory is still there and "cd .unionfs"
 or "ls -l .unionfs" still work. Also, libfuse will create .fuse_hidden*
-files, if a file is open, but will be deleted. Those fuse meta files also
-will be invisble. This option is especially usufull for
-package builders.
+files, if a file is open, but will be deleted. Those fuse meta files will
+be invisible as well. This option is especially useful for package builders.
 .TP
 \fB\-d
-Enable debugging for unionfs and libfuse. Useful for developers if the code
+Enable debugging for unionfs and libfuse. Useful for developers
 if the code does not behave as expected. Debug information will be written
 to stderr and a debug file (./unionfs_debug.log by default).
 .TP
@@ -70,14 +69,14 @@ Might be removed in future versions.
 \fB\-o relaxed_permissions
 Usually we automatically add the libfuse option "-odefault_permissions"
 so that libfuse takes over permission checks. However, if running not
-as root (so as uid =! 0  and gid != 0), permissions of the underlying
-filesystem are already sufficient. In order to prevent from severe
+as root (so as UID\ !=\ 0 and GID\ !=\ 0), permissions on the underlying
+filesystem are already sufficient. In order to prevent severe
 security issues, this option is not allowed if running as root.
 .TP
 \fB\-o statfs_omit_ro
-By default blocks of all branches are counted in statfs() calls
-(e.g. by 'df'). On setting this option read-only branches will be omitted
-for the summary of blocks. This may sound weird but it actually fixes
+By default, blocks of all branches are counted in statfs() calls
+(e.g. by 'df'). With this option, read-only branches will be omitted
+from the summary of blocks. This may sound weird, but it actually fixes
 "wrong" percentage of free space.
 .TP
 .SH "Options to libfuse"

--- a/man/unionfs.8
+++ b/man/unionfs.8
@@ -32,18 +32,26 @@ may be used for live CDs or live USB sticks, etc. So it can serve
 "/" as filesystem. If you do not specify this option and try to use
 it for "/", it will deadlock on calling 'pivot_root'.
 If you set this option, you also need to specify the branches relatively
-to the given chroot directory. See examples/S01a-unionfs-live-cd.sh
+to the given chroot directory. See
+.I examples/S01a-unionfs-live-cd.sh
 for an example.
 .TP
 \fB\-o cow
 Enable copy\-on\-write
 .TP
 \fB\-o hide_meta_files
-In our unionfs root path we have a .unionfs directory that includes
+In our unionfs root path we have a
+.I .unionfs
+directory that includes
 metadata, such as hidden (deleted) files. This option makes this
-directory invisible from readdir(), so for example "ls -la /union_root/"
-will not show it. However, this directory is still there and "cd .unionfs"
-or "ls -l .unionfs" still work. Also, libfuse will create .fuse_hidden*
+directory invisible from readdir(), so for example
+.B ls -la /union_root
+will not show it. However, this directory is still there and
+.B cd .unionfs
+or
+.B ls -l .unionfs
+still work. Also, libfuse will create
+.I \%.fuse_hidden*
 files, if a file is open, but will be deleted. Those fuse meta files will
 be invisible as well. This option is especially useful for package builders.
 .TP
@@ -67,7 +75,8 @@ Since version 0.23 without any effect, just left over for compatibility.
 Might be removed in future versions.
 .TP
 \fB\-o relaxed_permissions
-Usually we automatically add the libfuse option "-odefault_permissions"
+Usually we automatically add the libfuse option
+.B \-o \%default_permissions
 so that libfuse takes over permission checks. However, if running not
 as root (so as UID\ !=\ 0 and GID\ !=\ 0), permissions on the underlying
 filesystem are already sufficient. In order to prevent severe
@@ -81,12 +90,15 @@ from the summary of blocks. This may sound weird, but it actually fixes
 .TP
 .SH "Options to libfuse"
 There are several further options available, which don't directly apply to
-unionfs, but to libfuse. Please run "unionfs --help" to see these.
-We already set the "-o default-permissions" options on our own.
+unionfs, but to libfuse. Please run
+.B unionfs \-\-help
+to see these. We already set
+.B \-o \%default_permissions
+option on our own.
 .SH "EXAMPLES"
 .Vb 5
 \& unionfs \-o cow,max_files=32768 \e
-\&              -o allow_other,use_ino,suid,dev,nonempty \e
+\&              \-o allow_other,use_ino,suid,dev,nonempty \e
 \&              /u/host/etc=RW:/u/group/etc=RO:/u/common/etc=RO \e
 \&              /u/union/etc
 .Ve


### PR DESCRIPTION
The first commit fixes some obvious typos ("relativly", "invisble", "usufull"), grammar slips ("several directory", "prevent from", "omitted for") and missing commas.

The second commit borrows formatting convention from `man mount` (`.I` for paths, `.B` for commands) and prevents line-breaks inside option name `default_permissions`.

The third commit changes wording in two paragraphs which I think were a bit dense. And in the case of `max_files` also slightly incorrect (files are countable, and you can't exceed ulimit).
