### PR TITLE
Update to libfuse version 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if (UNIX AND APPLE)
 	link_directories("/usr/local/lib")
 endif()
 
-add_definitions(-D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=26)
+add_definitions(-D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=30)
 
 option(WITH_XATTR "Enable support for extended attributes" OFF)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,9 +7,9 @@ set(UNIONFSCTL_SRCS unionfsctl.c)
 add_executable(unionfs ${UNIONFS_SRCS} ${HASHTABLE_SRCS})
 
 if (UNIX AND NOT APPLE)
-    target_link_libraries(unionfs fuse pthread rt)
+    target_link_libraries(unionfs fuse3 pthread rt)
 else()
-    target_link_libraries(unionfs fuse pthread)
+    target_link_libraries(unionfs fuse3 pthread)
 endif()
 
 add_executable(unionfsctl ${UNIONFSCTL_SRCS})

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 CFLAGS += -Wall -fPIC
-CPPFLAGS += $(shell pkg-config --cflags fuse)
-CPPFLAGS += -DFUSE_USE_VERSION=29
+CPPFLAGS += $(shell pkg-config --cflags fuse3)
+CPPFLAGS += -DFUSE_USE_VERSION=30
 
 CPPFLAGS += -DLIBC_XATTR # glibc nowadays includes xattr
 # CPPFLAGS += -DLIBATTR_XATTR # define this to libattr xattr include
@@ -10,7 +10,7 @@ CPPFLAGS += -DLIBC_XATTR # glibc nowadays includes xattr
 
 LDFLAGS +=
 
-LIB = $(shell pkg-config --libs fuse) -lpthread
+LIB = $(shell pkg-config --libs fuse3) -lpthread
 
 HASHTABLE_OBJ = hashtable.o hashtable_itr.o
 LIBUNIONFS_OBJ = fuse_ops.o opts.o debug.o findbranch.o readdir.o \

--- a/src/general.c
+++ b/src/general.c
@@ -40,7 +40,7 @@ static int filedir_hidden(const char *path) {
 	if (!uopt.cow_enabled) RETURN(false);
 
 	char p[PATHLEN_MAX];
-	if (strlen(path) + strlen(HIDETAG) > PATHLEN_MAX) RETURN(-ENAMETOOLONG);
+	if (strlen(path) + strlen(HIDETAG) + 1 > PATHLEN_MAX) RETURN(-ENAMETOOLONG);
 	snprintf(p, PATHLEN_MAX, "%s%s", path, HIDETAG);
 	DBG("%s\n", p);
 

--- a/src/opts.h
+++ b/src/opts.h
@@ -8,7 +8,7 @@
 #define OPTS_H
 
 
-#include <fuse.h>
+#include <fuse3/fuse.h>
 #include <stdbool.h>
 
 #include "unionfs.h"

--- a/src/readdir.c
+++ b/src/readdir.c
@@ -110,11 +110,12 @@ static void read_whiteouts(const char *path, struct hashtable *whiteouts, int br
 /**
  * unionfs-fuse readdir function
  */
-int unionfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi) {
+int unionfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi, enum fuse_readdir_flags flags) {
 	DBG("%s\n", path);
 
 	(void)offset;
 	(void)fi;
+	(void)flags;
 	int i = 0;
 	int rc = 0;
 
@@ -173,7 +174,7 @@ int unionfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t o
 			st.st_ino = de->d_ino;
 			st.st_mode = de->d_type << 12;
 
-			if (filler(buf, de->d_name, &st, 0)) break;
+			if (filler(buf, de->d_name, &st, 0, 0)) break;
 		}
 
 		closedir(dp);

--- a/src/readdir.h
+++ b/src/readdir.h
@@ -1,9 +1,9 @@
 #ifndef READDIR_H
 #define READDIR_H
 
-#include <fuse.h>
+#include <fuse3/fuse.h>
 
-int unionfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi);
+int unionfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi, enum fuse_readdir_flags flags);
 int dir_not_empty(const char *path);
 
 #endif

--- a/src/unionfs.c
+++ b/src/unionfs.c
@@ -10,7 +10,7 @@
 *            Bernd Schubert <bernd-schubert@gmx.de>
 */
 
-#include <fuse.h>
+#include <fuse3/fuse.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
I think this is the minimum to upgrade to libfuse version 3.0. I've tried it linking against version 3.10 with `FUSE_USE_VERSION=30` and `FUSE_USE_VERSION=35`.