### PR TITLE
Apply patches from Debian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,5 +46,7 @@ ELSE (WITH_XATTR)
 	add_definitions(-DDISABLE_XATTR)
 ENDIF (WITH_XATTR)
 
+INSTALL(PROGRAMS mount.unionfs DESTINATION sbin)
+
 add_subdirectory(src)
 add_subdirectory(man)

--- a/man/unionfs.8
+++ b/man/unionfs.8
@@ -133,7 +133,7 @@ that might be added in later releases.
 .Ve
 .SH "AUTHORS"
 .B unionfs\-fuse
-Original implemention by Radek Podgorny <radek@podgorny.cz>
+Original implementation by Radek Podgorny <radek@podgorny.cz>
 .SH "COPYRIGHT"
 Radek Podgorny <radek\@podgorny.cz>, Bernd Schubert <bernd\-schubert\@gmx.de>
 .SH "THANKS"


### PR DESCRIPTION
These two patches come from https://sources.debian.org/src/unionfs-fuse/1.0-1/debian/patches/. I can't find any obvious author information, so I have attributed them to the debian maintainer who uploaded the 1.0-1 release (the patches were not present in the previous 0.24-2.1 release). They have very rough timestamps (from 2015) based on the timestamp in the debian changelog file.