### PR TITLE
correct the log priority for the failed mkdir in cow

### DIFF
--- a/src/cow.c
+++ b/src/cow.c
@@ -54,7 +54,7 @@ static int do_create(const char *path, int nbranch_ro, int nbranch_rw) {
 
 	res = mkdir(dirp, buf.st_mode);
 	if (res == -1) {
-		USYSLOG(LOG_DAEMON, "Creating %s failed: \n", dirp);
+		USYSLOG(LOG_ERR, "Creating %s failed: \n", dirp);
 		RETURN(1);
 	}
 


### PR DESCRIPTION
This fixes a typo when logging a failed directory create. 