### PR TITLE
Fix crashes and edge cases in cow-copy

### DIFF
--- a/src/cow.c
+++ b/src/cow.c
@@ -61,7 +61,8 @@ int cow_cp(const char *path, int branch_ro, int branch_rw, bool copy_dir) {
 	DBG("%s\n", path);
 
 	// create the path to the file
-	path_create_cutlast_cow(path, branch_ro, branch_rw);
+	int res = path_create_cutlast_cow(path, branch_ro, branch_rw);
+	if (res != 0) RETURN(res);
 
 	char from[PATHLEN_MAX], to[PATHLEN_MAX];
 	if (BUILD_PATH(from, uopt.branches[branch_ro].path, path)) {
@@ -88,7 +89,6 @@ int cow_cp(const char *path, int branch_ro, int branch_rw, bool copy_dir) {
 	lstat(cow.from_path, &buf);
 	cow.stat = &buf;
 
-	int res;
 	switch (buf.st_mode & S_IFMT) {
 		case S_IFLNK:
 			res = copy_link(&cow);

--- a/src/cow_utils.c
+++ b/src/cow_utils.c
@@ -91,7 +91,9 @@ int setfile(const char *path, struct stat *fs)
 	* chown.  If chown fails, lose setuid/setgid bits.
 	*/
 	if (chown(path, fs->st_uid, fs->st_gid)) {
-		if (errno != EPERM) {
+		/* EPERM if no permissions
+		 * EINVAL if user was nobody or group was nogroup */
+		if (errno != EPERM && errno != EINVAL) {
 			USYSLOG(LOG_WARNING, "chown: %s", path);
 			rval = 1;
 		}

--- a/src/findbranch.c
+++ b/src/findbranch.c
@@ -208,7 +208,11 @@ int __find_rw_branch_cutlast(const char *path, int rw_hint) {
 		goto out;
 	}
 
-	if (path_create_cow(dname, branch, branch_rw) == 0) branch = branch_rw; // path successfully copied
+	if (path_create_cow(dname, branch, branch_rw) == 0) {
+		branch = branch_rw; // path successfully copied
+	} else {
+		branch = -1; // failed to copy path, error
+	}
 
 out:
 	free(dname);


### PR DESCRIPTION
Fixed:
- unionfs-fuse crashes when read-only branch is owned by nobody (uid 65534), even when the user has read permissions to it. This commonly happens on NFS or when running inside a user namespace (`unshare --user`).
- In a certain case if parent path creation fails during cow-copy, writes to files are redirected to a read-only branch (!!!).