### PR TITLE
Add an "all_writable" option to allow overwriting non-writable files in backing directories.

### DIFF
--- a/man/unionfs.8
+++ b/man/unionfs.8
@@ -88,6 +88,10 @@ By default, blocks of all branches are counted in statfs() calls
 from the summary of blocks. This may sound weird, but it actually fixes
 "wrong" percentage of free space.
 .TP
+\fB\-o all_writable
+Treat read\-only files and directories on backing filesystems as writable.
+Implies copy\-on\-write.
+.TP
 .SH "Options to libfuse"
 There are several further options available, which don't directly apply to
 unionfs, but to libfuse. Please run

--- a/src/cow.c
+++ b/src/cow.c
@@ -111,6 +111,8 @@ int cow_cp(const char *path, int branch_ro, int branch_rw, bool copy_dir) {
 			USYSLOG(LOG_WARNING, "COW of sockets not supported: %s\n", cow.from_path);
 			RETURN(1);
 		default:
+			if (uopt.all_writable)
+				buf.st_mode |= (buf.st_mode & 0444) >> 1;
 			res = copy_file(&cow);
 	}
 

--- a/src/fuse_ops.c
+++ b/src/fuse_ops.c
@@ -204,6 +204,9 @@ static int unionfs_getattr(const char *path, struct stat *stbuf, struct fuse_fil
 	int res = lstat(p, stbuf);
 	if (res == -1) RETURN(-errno);
 
+        // In all writable mode, enable write in all cases where we have read.
+        if (uopt.all_writable) stbuf->st_mode |= (stbuf->st_mode & 0444) >> 1;
+
 	/* This is a workaround for broken gnu find implementations. Actually,
 	 * n_links is not defined at all for directories by posix. However, it
 	 * seems to be common for filesystems to set it to one if the actual value

--- a/src/general.c
+++ b/src/general.c
@@ -238,6 +238,7 @@ static int do_create(const char *path, int nbranch_ro, int nbranch_rw) {
 		sprintf(o_dirp, "%s%s", uopt.branches[nbranch_ro].path, path);
 		res = stat(o_dirp, &buf);
 		if (res == -1) RETURN(1); // lower level branch removed in the mean time?
+		if (uopt.all_writable) buf.st_mode |= (buf.st_mode & 0444) >> 1;
 	}
 
 	bool _call_setfile = true;

--- a/src/opts.c
+++ b/src/opts.c
@@ -370,6 +370,10 @@ int unionfs_opt_proc(void *data, const char *arg, int key, struct fuse_args *out
 		case KEY_PRESERVE_BRANCH:
 			uopt.preserve_branch = true;
 			return 0;
+		case KEY_ALL_WRITABLE:
+			uopt.all_writable = true;
+			uopt.cow_enabled = true;
+			return 0;
 		case KEY_DEBUG_FILE:
 			uopt.dbgpath = get_opt_str(arg, "debug_file");
 			uopt.debug = true;

--- a/src/opts.h
+++ b/src/opts.h
@@ -22,6 +22,7 @@ typedef struct {
 
 	bool cow_enabled;
 	bool preserve_branch;
+	bool all_writable;
 	bool statfs_omit_ro;
 	int doexit;
 	int retval;
@@ -39,6 +40,7 @@ enum {
 	KEY_CHROOT,
 	KEY_COW,
 	KEY_PRESERVE_BRANCH,
+	KEY_ALL_WRITABLE,
 	KEY_DEBUG_FILE,
 	KEY_DIRS,
 	KEY_HELP,

--- a/src/unionfs.c
+++ b/src/unionfs.c
@@ -25,6 +25,7 @@ static struct fuse_opt unionfs_opts[] = {
 	FUSE_OPT_KEY("chroot=%s,", KEY_CHROOT),
 	FUSE_OPT_KEY("cow", KEY_COW),
 	FUSE_OPT_KEY("preserve_branch", KEY_PRESERVE_BRANCH),
+	FUSE_OPT_KEY("all_writable", KEY_ALL_WRITABLE),
 	FUSE_OPT_KEY("debug_file=%s", KEY_DEBUG_FILE),
 	FUSE_OPT_KEY("dirs=%s", KEY_DIRS),
 	FUSE_OPT_KEY("--help", KEY_HELP),

--- a/test_all.py
+++ b/test_all.py
@@ -367,6 +367,40 @@ class UnionFS_RW_RO_COW_TestCase(Common, unittest.TestCase):
 		#self.assertFalse(os.path.isdir('union/common_dir'))
 
 
+class UnionFS_RW_RO_AW_TestCase(Common, unittest.TestCase):
+	def setUp(self):
+		super().setUp()
+		self.mount('-o all_writable,debug_file=/usr/local/google/home/mmuller/w/unionfs-fuse/log.txt rw1=rw:ro1=ro union')
+		os.chmod('ro1/ro1_dir', 0o500)
+		os.chmod('ro1/ro1_file', 0o400)
+
+	def tearDown(self):
+		os.chmod('ro1/ro1_dir', 0o700)
+		os.chmod('ro1/ro1_file', 0o600)
+		super().tearDown()
+
+	def test_mkdir(self):
+		os.mkdir('union/ro1_dir/mydir')
+		self.assertTrue(os.access('union/ro1_dir/mydir', os.W_OK))
+
+	def test_write_file(self):
+		write_to_file('union/ro1_file', 'overwrite!')
+		self.assertEqual(read_from_file('union/ro1_file'), 'overwrite!')
+
+	def test_write_to_ro_dir(self):
+		write_to_file('union/ro1_dir/new_file', 'something')
+		self.assertEqual(read_from_file('union/ro1_dir/new_file'), 'something')
+
+	def test_rmdir(self):
+		os.remove('union/ro1_dir/ro1_file')
+		os.rmdir('union/ro1_dir')
+		self.assertFalse(os.path.exists('union/ro1_dir'))
+
+	def test_rmfile(self):
+		os.remove('union/ro1_file')
+		self.assertFalse(os.path.exists('union/ro1_file'))
+
+
 class UnionFS_RO_RW_TestCase(Common, unittest.TestCase):
 	def setUp(self):
 		super().setUp()


### PR DESCRIPTION
It's often useful to create overlays based on read-only filesystems.  For example, one might mount a CDROM with the intention of performing local modifications to it, thus avoiding the need to copy the entire contents of the volume to the local filesystem.

The "all_writable" option augments copy-on-write to treat all files and directories on the backing, read-only fiilesystems that are readable by the user as writable.  A read-only file's permissions will include the "w" bits in all cases where there is a corresponding "r" bit (for example, "`r-xr-x---`" will get promoted to  "`rwxrwx---`") and the file/directory will be created with the corresponding permissions during a copy-on-write.