### PR TITLE
`cmake.yml`: Downgrade to GCC 12 for macOS 12 to fix CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -60,7 +60,7 @@ jobs:
           brew install --cask macfuse
 
       - name: Checkout Git branch
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4.1.4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
 
       - name: 'Configure with CMake'
         run: |-

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,7 +30,7 @@ jobs:
             clang_major_version: 18
             runs-on: ubuntu-24.04
           # macFUSE on macOS
-          - cc: gcc-13
+          - cc: gcc-12
             clang_major_version: null
             runs-on: macos-12
           - cc: clang-15

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -43,7 +43,7 @@ jobs:
             python3-pytest
 
       - name: Checkout Git branch
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4.1.4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
 
       - name: 'Build and test (without coverage)'
         run: |-


### PR DESCRIPTION
Seems like GitHub Actions managed to break GCC 13 with a recent update:
```
Worked: macOS 12.7.4 20240514.3 + GCC 13.2.0
Broken: macOS 12.7.5 20240602.1 + GCC 13.3.0
                   ^      ^^^^^          ^
```
Result `not found` for test `Looking for include file sys/xattr.h` is the earliest indicator something broke on their side during the build.

Likely related to https://github.com/actions/runner-images/issues/9997 .

PS: I'm attaching a CI build log before and after things broke, with timestamps removed to ease diffing:
- [`job-logs-good.txt`](https://github.com/user-attachments/files/15858940/job-logs-good.txt)
- [`job-logs-bad.txt`](https://github.com/user-attachments/files/15858946/job-logs-bad.txt)


CC @rpodgorny 