### PR TITLE
Fix directory rename hiding files from lower branches

### DIFF
--- a/src/cow.c
+++ b/src/cow.c
@@ -146,27 +146,12 @@ int copy_directory(const char *path, int branch_ro, int branch_rw) {
 			break;
 		}
 
-		char from_member[PATHLEN_MAX], to_member[PATHLEN_MAX];
-		if (BUILD_PATH(from_member, uopt.branches[branch_ro].path, member)) {
-			res = -ENAMETOOLONG;
-			break;
-		}
-		if (BUILD_PATH(to_member, uopt.branches[branch_rw].path, member)) {
-			res = -ENAMETOOLONG;
-			break;
-		}
-
 		// Generally if the target file already exists, we should not copy
 		// anything. Directories are a special case as their contents may still
 		// need to be merged.
-		struct stat buf;
-		if (
-			!lstat(to_member, &buf) &&
-			(
-				(buf.st_mode & S_IFMT) != S_IFDIR ||
-				(!lstat(from_member, &buf) && (buf.st_mode & S_IFMT) != S_IFDIR)
-			)
-		) {
+		bool is_dir = false;
+		if (branch_contains_path(branch_rw, member, &is_dir) &&
+			(!is_dir || (branch_contains_path(branch_ro, member, &is_dir) && !is_dir))) {
 			// File already exists in target and either source or target is not
 			// a directory, skip it
 			DBG("file %s copy skipped, exists in target\n", member);

--- a/src/cow.h
+++ b/src/cow.h
@@ -9,7 +9,7 @@
 
 #include <sys/stat.h>
 
-int cow_cp(const char *path, int branch_ro, int branch_rw, bool copy_dir);
+int cow_cp(const char *path, int branch_ro, int branch_rw, bool recursive);
 int path_create_cow(const char *path, int nbranch_ro, int nbranch_rw);
 int path_create_cutlast_cow(const char *path, int nbranch_ro, int nbranch_rw);
 int copy_directory(const char *path, int branch_ro, int branch_rw);

--- a/src/findbranch.c
+++ b/src/findbranch.c
@@ -51,7 +51,7 @@
 #include "debug.h"
 #include "usyslog.h"
 
-static bool branch_contains_path(int branch, const char *path, bool *is_dir) {
+bool branch_contains_path(int branch, const char *path, bool *is_dir) {
 	if (branch < 0 || branch >= uopt.nbranches) {
 		RETURN(false);
 	}

--- a/src/findbranch.h
+++ b/src/findbranch.h
@@ -18,6 +18,6 @@ int find_lowest_rw_branch(int branch_ro);
 int find_rw_branch_cutlast(const char *path);
 int __find_rw_branch_cutlast(const char *path, int rw_hint);
 int find_rw_branch_cow(const char *path);
-int find_rw_branch_cow_common(const char *path, bool copy_dir);
+int find_rw_branch_cow_recursive(const char *path);
 
 #endif

--- a/src/findbranch.h
+++ b/src/findbranch.h
@@ -12,6 +12,7 @@ typedef enum searchflag {
 	RWONLY
 } searchflag_t;
 
+bool branch_contains_path(int branch, const char *path, bool *is_dir);
 bool branch_contains_file_or_parent_dir(int branch, const char *path);
 int find_rorw_branch(const char *path);
 int find_lowest_rw_branch(int branch_ro);

--- a/test_all.py
+++ b/test_all.py
@@ -417,16 +417,23 @@ class UnionFS_RW_RO_RO_COW_TestCase(Common, unittest.TestCase):
 	def test_rmdir(self):
 		with self.assertRaises(OSError):
 			os.rmdir('union/ro1_dir')
+
 		os.remove('union/rw1_dir/rw1_file')
 		os.rmdir('union/rw1_dir')
-		self.assertFalse(os.path.isdir('union/rw1_dir'))
-		self.assertFalse(os.path.isdir('rw1/rw1_dir'))
+		self.assertFalse(os.path.exists('union/rw1_dir'))
+		self.assertFalse(os.path.exists('rw1/rw1_dir'))
+
 		os.rmdir('union/common_empty_dir')
-		# TODO: decide what the correct behaviour should be
-		#self.assertFalse(os.path.isdir('union/common_empty_dir'))
-		#os.remove('union/common_dir/common_file')
-		#os.rmdir('union/common_dir')
-		#self.assertFalse(os.path.isdir('union/common_dir'))
+		self.assertFalse(os.path.exists('union/common_empty_dir'))
+
+		os.remove('union/common_dir/common_file')
+		os.remove('union/common_dir/ro_common_file')
+		os.remove('union/common_dir/rw_common_file')
+		os.remove('union/common_dir/ro2_file')
+		os.remove('union/common_dir/ro1_file')
+		os.remove('union/common_dir/rw1_file')
+		os.rmdir('union/common_dir')
+		self.assertFalse(os.path.exists('union/common_dir'))
 
 
 class UnionFS_RO_RW_TestCase(Common, unittest.TestCase):


### PR DESCRIPTION
Fixes #91 

This PR fixes the old issue #91 with directory rename. Previously after renaming a directory, only the contents of the highest branch were cow-copied up to the read-write branch, hiding all content the directory had in lower branches. In this PR a new function is introduced that can do a cow-copy recursively for a directory tree in every branch. Now if a file is renamed and it's a non-directory, we do a normal cow-copy, but for directories we do this recursive cow-copy instead. Everything should now work as expected from a proper directory rename.

Doing a cow-copy recursively for a whole directory is significantly more complex that for a single file:
- We have to copy the directory from every branch because each of them might contain a different part of the directory's contents.
- We have to recursively copy every file in the directory in every branch.
- We have to check for each file if it already exists in the destination so we don't overwrite files from higher branches.
- We have to check for each file that it doesn't have a whiteout in any of the higher branches so we don't accidentally reintroduce it by copying.

Caveat: directory renaming is now much slower than before. That's the price of it working correctly.