### PR TITLE
Fix symlink handling

### DIFF
--- a/src/conf.h
+++ b/src/conf.h
@@ -7,12 +7,13 @@
 #ifndef CONF_H_
 #define CONF_H_
 
-#ifdef _XOPEN_SOURCE
+#if (defined _XOPEN_SOURCE || defined __APPLE__)
 
 // *at support, such as openat, utimensat, etc (see man 2 openat)
 #include <fcntl.h>
 #include <sys/stat.h>
-#if !defined (DISABLE_AT) && (_XOPEN_SOURCE >= 700 && _POSIX_C_SOURCE >= 200809L) \
+#if !defined (DISABLE_AT) && \
+    ((_XOPEN_SOURCE >= 700 && _POSIX_C_SOURCE >= 200809L) || (defined __APPLE__)) \
 	&& defined (AT_SYMLINK_NOFOLLOW)
 	#define UNIONFS_HAVE_AT
 #endif
@@ -36,4 +37,3 @@
 
 
 #endif // CONF_H_
-

--- a/src/fuse_ops.c
+++ b/src/fuse_ops.c
@@ -73,7 +73,12 @@ static int unionfs_chmod(const char *path, mode_t mode, struct fuse_file_info *f
 	char p[PATHLEN_MAX];
 	if (BUILD_PATH(p, uopt.branches[i].path, path)) RETURN(-ENAMETOOLONG);
 
-	int res = chmod(p, mode);
+  #ifdef UNIONFS_HAVE_AT
+	  int res = fchmodat(AT_FDCWD, p, mode, AT_SYMLINK_NOFOLLOW);
+  #else
+    int res = chmod(p, mode);
+  #endif
+
 	if (res == -1) RETURN(-errno);
 
 	RETURN(0);


### PR DESCRIPTION
This pull request fixes two related bugs:

1. On macOS `utimes` is used instead of `utimensat` even though the latter is available. To fix this a check for `defined __APPLE__` was added when deciding whether to define `UNIONFS_HAVE_AT`.
2. On all platforms, attempts to `chmod` a symlink itself (such as with `chmod -h`) always affect the target instead. This was fixed by using `fchmodat` with `AT_SYMLINK_NOFOLLOW` when available.

Fixes #156.