### PR TITLE
CI: Stop using about-to-be-removed image "macos-13"

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,7 +32,7 @@ jobs:
           # macFUSE on macOS
           - cc: gcc-12
             clang_major_version: null
-            runs-on: macos-13
+            runs-on: macos-14
           - cc: clang-15
             clang_major_version: 15
             runs-on: macos-14


### PR DESCRIPTION
> The macOS 13 runner image will be retired by December 4th, 2025.

CC @rpodgorny 