### PR TITLE
Make `mount.unionfs` helper POSIX-compliant

### DIFF
--- a/mount.unionfs
+++ b/mount.unionfs
@@ -1,9 +1,27 @@
-#!/bin/bash
-
-label=$1
-mpoint=$2
-shift 3
-dirs=${@##*,dirs=}
-dirs=${dirs/,/:}
-mount.fuse "unionfs#$dirs" "$mpoint" -o ${@%%,dirs=*} 
-
+#!/bin/sh
+set -f
+print_usage() { echo "usage: ${0##*/} <ignored> destination" \
+    "-o dirs=UNION_DIRS[,opt[,opts...]]"; }
+first_arg=y first_pos=y is_opt='' dirs=''
+IFS=; for arg in "$@"; do
+    [ -z "$first_arg" ] || { first_arg=; set --; }
+    if [ -n "$is_opt" ]; then
+        is_opt='' new_arg=''
+        IFS=,; for part in $arg; do
+            case "$part" in
+                dirs=*) dirs="${dirs:+$dirs:}${part#dirs=}" ;;
+                *) new_arg="${new_arg:+$new_arg,}$part" ;;
+            esac
+        done
+        [ -n "$new_arg" ] || continue
+        set -- "$@" -o "$new_arg"
+    elif [ "-o" = "$arg" ]; then
+        is_opt=y
+    elif [ -n "$first_pos" ] && [ "${arg#-}" = "$arg" ]; then
+        first_pos=''
+    else
+        set -- "$@" "$arg"
+    fi
+done
+[ -n "$dirs" ] && [ -z "$is_opt" ] || { print_usage >&2; exit 1; }
+exec mount.fuse "unionfs#$dirs" "$@"


### PR DESCRIPTION
This rewrites the `mount.unionfs` mount helper as a POSIX-compliant shell script instead of a Bash script.

The primary motivation is not only portability, but also correctness and robustness of argument handling.

Advantages of this change include:

* Bash is no longer required solely for the mount helper. This removes an unnecessary dependency and avoids warnings from distribution tooling (such as Arch Linux's `mkinitcpio`) that inspects mount helpers for initramfs compatibility.
* The previous implementation used unquoted parameter expansions when reconstructing the `mount.fuse` command line. This could result in unintended word splitting and pathname expansion (globbing), potentially altering the arguments passed to `mount.fuse`.
* The previous implementation relied on several assumptions about the exact structure of the command line. In particular, it assumed a fixed positional layout and expected `dirs=` to appear in a specific location within the option list. If arguments were provided in a different but still valid form, parsing could produce incorrect results.
* The previous implementation treated `$@` as if it were a single string and performed parameter expansions on it. This works only for a narrow set of argument layouts and becomes fragile as soon as options are rearranged, split into multiple arguments, or otherwise passed differently than expected.

Some concrete examples where the previous implementation could fail:

* It assumes that the `dirs=` option is the last option within the `-o` argument. For example: `mount -t unionfs none /mnt -o dirs=/lower:/upper,ro` would cause the helper to interpret `ro` as part of the directory list, producing an invalid `unionfs#...` source.
* It assumes a very specific argument layout and effectively expects all mount options to be contained in a single argument. Invocations such as `mount -t unionfs none /mnt -o ro -o dirs=/lower:/upper` are valid, but the previous implementation does not handle them correctly because it performs string operations on `$@` rather than processing arguments individually.

The new implementation takes a simple approach: it walks through the original argument vector, reconstructs it while preserving all arguments except for the first positional argument, extracts `dirs=` entries from `-o` option arguments, and finally invokes `mount.fuse "unionfs#$dirs"` with all remaining arguments passed through unchanged.

As a result, the helper no longer depends on a specific argument ordering and is significantly more tolerant of variations in how `mount` and other callers provide mount options. The implementation also remains fully POSIX-compliant and avoids Bash-specific features entirely.